### PR TITLE
Add `provenance` and `content_fingerprint` to `content_grounded` (v0.1)

### DIFF
--- a/tests/valid/event-standalone-grounded-provenance.json
+++ b/tests/valid/event-standalone-grounded-provenance.json
@@ -1,0 +1,25 @@
+{
+  "document_type": "event",
+  "schema_version": "0.1",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "agent_id": "agent-example",
+  "started_at": "2026-06-20T10:00:00Z",
+  "event": {
+    "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    "type": "content_grounded",
+    "timestamp": "2026-06-20T10:00:01Z",
+    "content_url": "https://example.com/article",
+    "content_id": "ISCC:KACYPXW445FTYNJ3",
+    "data": {
+      "scope": "turn",
+      "cached": true,
+      "provenance": "third_party_sourced",
+      "tokens_ingested": 512,
+      "content_fingerprint": {
+        "scheme": "iscc",
+        "detected": true,
+        "preserved_in_output": false
+      }
+    }
+  }
+}

--- a/tests/valid/event-standalone-grounded-provenance.json
+++ b/tests/valid/event-standalone-grounded-provenance.json
@@ -17,8 +17,7 @@
       "tokens_ingested": 512,
       "content_fingerprint": {
         "scheme": "iscc",
-        "detected": true,
-        "preserved_in_output": false
+        "detected": true
       }
     }
   }


### PR DESCRIPTION
Implements the two fields agreed in #5: an optional `provenance` enum and a scheme-agnostic `content_fingerprint` object on `content_grounded`, per @jchomat's proposal and @jalexspringer's direction.

### What this adds

**`provenance`** (`#/$defs/SourceProvenance`) — optional, on `content_grounded.data`, placed next to `cached`:
- enum: `agent_fetched` / `agent_cached` / `third_party_sourced`
- Resolves the `cached: true` ambiguity raised in #5 (suggestion 2): `cached` does not distinguish a self-cache from third-party-sourced content, and the two have different provenance. Agent-observable, so reporting cost is low.

**`content_fingerprint`** (`#/$defs/ContentFingerprint`) — optional object, on `content_grounded.data`:
- `scheme` (free string, required), `detected` (boolean, required), `preserved_in_output` (boolean, optional)
- `scheme` is deliberately a free string, not a closed enum, so techniques can evolve (ISCC, C2PA text provenance, syntactic watermarking, etc.) without dating the spec.

### On the two framing points from #5

**Inference, not observation.** Per @jalexspringer: `detected` and `preserved_in_output` are agent-reported and have no origin-side counterpart to corroborate against (the §7.3 gap). The field descriptions state explicitly that these are claims, not observed facts, and that consumers MUST treat them as inference. I have kept this in the field-level descriptions rather than inventing an evidentiary-tier enum, so that it slots cleanly under the broader claims-vs-corroborated-facts section when that lands for v0.1 — happy to rework the labelling to match whatever shape that section takes.

**Wider than the cache case.** Per @jalexspringer: the object is described to cover derived-content tracing, not only cache disambiguation — the case where an intermediary serves a summary (or a summary of a summary) and the original never enters the final context, so a preserved, detectable fingerprint is the one publisher-side signal that the derived content traces to the source. C2PA text provenance then sits as one `scheme` under the object rather than as a separate dependency. The description is written to cover both the cache case and this derived/laundered case.

### Choices worth a look

- **Placement.** `provenance` sits immediately after `cached` (semantic locality — it disambiguates that flag). `content_fingerprint` is appended after the existing grounding fields. Both are additive and optional; nothing existing changes.
- **`required` within `content_fingerprint`.** `scheme` and `detected` are required *if the object is present* (an empty fingerprint claim carries no information). `preserved_in_output` is optional, since an agent may detect a mark on input without tracking output survival. Easy to relax if you'd rather all three be optional.
- **No new `EventType` or top-level fields.** Everything lives under `content_grounded.data`, consistent with how `scope`, `cached`, `content_hash` etc. are already scoped.

### Tests

- Existing harness: **50/50 still pass** (no regressions).
- Added one valid fixture (`tests/valid/event-standalone-grounded-provenance.json`) exercising both new fields → **51/51 pass**.

### Not included (deliberately)

- The §8.9 deferral line and the §6.4 prose (separate, in a doc PR if you prefer prose and schema split).
- Any MUST-level requirement. `provenance` is proposed as optional/SHOULD-at-Grounding in the prose; per @jalexspringer the MUST question is held for the v1.0 discussion.