### PR TITLE
Define v1 presentation semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a preview specification. Field names, event types, and schema structure 
 
 ## Problem
 
-AI agents retrieve a content owner's content, use it to generate responses, and sometimes cite it. Content owners currently see an initial retrieval event - HTTP requests hitting their servers or access logs from content repositories. Whether the content actually influenced the response, whether it was cited, whether a user saw the citation, whether they clicked through - is not reported back to content owners.
+AI agents retrieve a content owner's content, use it to generate responses, and sometimes cite it. Content owners currently see an initial retrieval event - HTTP requests hitting their servers or access logs from content repositories. Whether the content actually entered a generation context, whether it was cited, whether content or a source reference was made perceivable, and whether anyone interacted with that presentation is not reported back to content owners.
 
 Platforms self-report usage metrics (if they report at all), and content owners have no way to verify the numbers or compare across platforms.
 
@@ -30,7 +30,7 @@ Content Telemetry tracks content through five stages:
 Retrieved    →  content fetched over HTTP (content owner can see this today)
   Grounded   →  content loaded into the agent's generation context
     Cited    →  content explicitly referenced in the response
-      Displayed  →  user saw it - a reference, or the content embedded in the answer
+      Presented  →  content or a source reference made perceivable on a recipient-facing surface
         Engaged  →  user clicked, copied, shared, or directed the agent to act
 ```
 
@@ -44,7 +44,7 @@ The gaps between stages show how content was used:
 
 The grounding event captures the boundary "this content entered the agent's generation context." It is architecture-neutral and decoupled from retrieval: content cached by the agent for days still produces a grounding event in every session it influences.
 
-Grounding and display record two different kinds of influence: grounding means the content influenced the agent, display means it reached the user. The two diverge as agent experiences move beyond the chat window - an agentic browser can render a page to the user that never entered a generation context, reported as a `content_displayed` event with `display_type: embed` and no grounding event.
+Grounding and presentation record different boundary crossings: grounding means the content entered a generation context; presentation means content or a source reference was made perceivable on a recipient-facing surface. Presentation does not prove attention. The two diverge as agent experiences move beyond the chat window - an agentic browser can render a page that never entered a generation context, reported as a `content_presented` event with `presentation_kind: content` and `presentation_type: embed` and no grounding event.
 
 ## Design principles
 
@@ -101,9 +101,12 @@ A user asks an AI agent about UK interest rates. The agent grounds its response 
       }
     },
     {
+      "id": "550e8400-e29b-41d4-a716-446655440001",
       "type": "content_cited",
       "timestamp": "2026-03-28T09:00:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:paragraph:2",
       "content_url": "https://www.ft.com/content/abc123",
       "content_id": "ft:abc123",
       "data": {
@@ -112,12 +115,19 @@ A user asks an AI agent about UK interest rates. The agent grounds its response 
       }
     },
     {
-      "type": "content_displayed",
+      "id": "550e8400-e29b-41d4-a716-446655440002",
+      "type": "content_presented",
       "timestamp": "2026-03-28T09:00:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:paragraph:2",
+      "citation_id": "550e8400-e29b-41d4-a716-446655440001",
       "content_url": "https://www.ft.com/content/abc123",
       "content_id": "ft:abc123",
-      "data": { "display_type": "link" }
+      "data": {
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
+      }
     },
     {
       "type": "turn_completed",
@@ -134,7 +144,7 @@ A user asks an AI agent about UK interest rates. The agent grounds its response 
 }
 ```
 
-The content owner can derive: FT article `abc123` was in context for the response, cited as a paraphrase, link was displayed, user never clicked, ads were shown alongside.
+The content owner can derive: FT article `abc123` was in context for the response, cited as a paraphrase, its link was made perceivable, and no engagement was reported; ads were shown alongside.
 
 ## Relationship to other protocols
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -11,7 +11,7 @@
 3. [Terms and definitions](#3-terms-and-definitions)
 4. [Concepts](#4-concepts) - roles, sessions, event lifecycle, source roles, content identification
 5. [Schema](#5-schema) - session, event, event types, conversation turn, privacy, intent, conformance levels
-6. [Data profiles](#6-data-profiles) - retrieval, edge enrichment, origin enrichment, grounding, citation, display, engagement
+6. [Data profiles](#6-data-profiles) - retrieval, edge enrichment, origin enrichment, grounding, citation, presentation, engagement
 7. [Transport](#7-transport) - delivery formats, Content-Telemetry-ID header
 8. [Manifest](#8-manifest) - discovery, schema, operator, keys, telemetry, domains
 9. [Privacy](#9-privacy) - data minimisation, recommended levels, retention
@@ -169,7 +169,7 @@ Session
 │   ├── content_retrieved    (HTTP layer)
 │   ├── content_grounded     (influence layer)
 │   ├── content_cited        (response layer)
-│   ├── content_displayed    (UI layer)
+│   ├── content_presented    (recipient-facing surface)
 │   ├── turn_completed
 │   ├── content_engaged      (user action layer)
 │   └── ...
@@ -190,19 +190,19 @@ Content moves through five stages during an agent interaction:
 
    Grounding is architecture-neutral: same event whether the agent uses RAG, chain-of-thought reasoning, embeddings, or multi-step delegation (see section 6.4 for architecture-specific guidance). Grounding is decoupled from retrieval: content may be grounded from a live fetch, from agent-side cache, or from a pre-loaded index. Only the agent can report grounding events.
 
-3. **Cited** - Content explicitly referenced in the agent's response: quoted, paraphrased, or linked. A subset of grounded content. Content can influence every response in a session without being cited once.
+3. **Cited** - An output artifact explicitly associates identified source content with a response, claim, passage, quotation, or other output element. Citation is an output-construction relationship, not evidence that the output was delivered. A subset of grounded content is commonly cited, but a citation can also be emitted without a matching grounding event when an agent produces an uncorroborated or hallucinated source association.
 
-4. **Displayed** - Content presented to the end user: a reference (a link, snippet, inline quote, or preview card) or the content itself embedded in the response surface (an iframe, a page rendered by an agentic browser, an embedded media player). Not all citations result in display (e.g., when the agent uses content internally without surfacing the source).
+4. **Presented** - Content or a source reference was rendered, played, spoken, embedded, or otherwise made perceivable on a recipient-facing surface. Presentation does not assert that a person noticed or attended to it. `presentation_kind` distinguishes source content (including a reproduced excerpt or media) from a source reference (such as a link, credit, or card). Not all citations are presented: an output can be stored, suppressed, or passed to another system before delivery.
 
-   Grounding and display record two different kinds of influence: grounding records that content influenced the agent, display records that it reached the user. As agent experiences evolve beyond the chat window the two diverge - content can shape an answer whose source the user never sees, and an agent can render content to the user that never entered a generation context (see *Departures from the funnel model* below).
+   Grounding and presentation record different boundary crossings: grounding records entry into a generation context, while presentation records a recipient-facing delivery occurrence. As agent experiences evolve beyond the chat window the two diverge - content can shape an answer whose source is never presented, and an agent can present content that never entered a generation context (see *Departures from the funnel model* below).
 
-5. **Engaged** - The user acted on displayed or cited content: clicked a link, expanded a preview, copied text, shared the response, or directed the agent to act on the content on their behalf (opening the linked page, retrieving more from the source). Engagement connects the preceding events to down-funnel activity: a click-out carries a `ctx_token` that a destination can resolve to the session's click manifest - the content that influenced the response (section 7.1).
+5. **Engaged** - The recipient or agent performed an observable action on a presentation: clicked a link, expanded a preview, copied text, shared the response, or directed the agent to act on the content. It does not imply attention beyond the reported action. `presentation_id` links the action to the exact presentation occurrence; a click-out can also carry a `ctx_token` that a destination resolves to the session's click manifest (section 7.1).
 
 ```
 Retrieved (HTTP layer, cacheable)
   → Grounded (influence layer, per-session or per-turn)
     → Cited (response layer, per-turn)
-      → Displayed (UI layer, per-turn)
+      → Presented (recipient-facing surface, per-turn)
         → Engaged (user action layer)
 ```
 
@@ -210,16 +210,16 @@ Each stage is typically a progressively narrower subset. The ratios between stag
 
 - **Retrieval-to-grounding** measures content fetched but not used (irrelevant, stale, or a competing source was preferred)
 - **Grounding-to-citation** measures content that influenced the response without explicit attribution
-- **Citation-to-display** measures content attributed internally but not shown to the user
-- **Display-to-engagement** measures interactions where the user did or did not visit the source
+- **Citation-to-presentation** measures source associations constructed in output but not made perceivable
+- **Presentation-to-engagement** measures observable actions on exact presentation occurrences
 
 #### Departures from the funnel model
 
 Three cases break the strict subset model:
 
-- **Displayed without cited.** An agent may display content references (e.g., a "Sources" sidebar) without citing the content in the response text. In this case, a `content_displayed` event exists with no corresponding `content_cited` event.
+- **Presented without cited.** An agent may present content references (e.g., a "Sources" sidebar) without semantically associating them with a response element. In this case, a `content_presented` event exists with no corresponding `content_cited` event.
 - **Cited without grounded.** A hallucinated citation references content the agent never retrieved or loaded into context. The `content_cited` event has no preceding `content_grounded` event. Telemetry consumers SHOULD treat uncorroborated citations (no matching grounding event) as lower-confidence signals.
-- **Displayed without grounded.** An agent can render content to the user without that content entering a generation context: an agentic browser showing a page, an embedded video played in the response surface. A `content_displayed` event (typically `display_type: embed`) exists with no corresponding `content_grounded` event. The content influenced the user directly rather than through the model, and the engagement that follows it is consumption the content owner cannot otherwise observe.
+- **Presented without grounded.** An agent can present content without that content entering a generation context: an agentic browser showing a page or an embedded video played on a response surface. A `content_presented` event (typically `presentation_kind: content` and `presentation_type: embed`) exists with no corresponding `content_grounded` event.
 
 These cases are valid. Emitters SHOULD produce the events that reflect what actually happened, even when the result does not follow the typical funnel ordering.
 
@@ -230,7 +230,7 @@ Conversation turns overlay this lifecycle:
 1. **Turn started** - user submits a query
 2. **Turn completed** - agent finishes response
 
-A single grounding event with session scope influences all subsequent turns. Citation, display, and engagement events occur within specific turns.
+A single grounding event with session scope influences all subsequent turns. Citation, presentation, and engagement events occur within specific turns.
 
 ### 4.4 Source roles
 
@@ -247,7 +247,7 @@ The `origin` and `edge` source roles enable content owners to report AI agent tr
 
 A marketplace operating as both emitter and telemetry consumer receives telemetry from platforms (as a consumer), resolves content owner identity from `content_id` or `content_url`, and generates per-content-owner usage reports. The marketplace's own `source_role: index` events provide a corroboration layer - it can cross-reference what it served against what platforms reported using.
 
-`content_grounded`, `content_cited`, and `content_displayed` events are reported by the agent (or agent operator) only. These events describe what happened inside the agent or in the agent's user interface, which is not observable from the content owner's infrastructure.
+`content_grounded`, `content_cited`, and `content_presented` events are reported by the agent (or agent operator) only. These events describe what happened inside the agent, during output construction, or on a recipient-facing surface, which is not observable from the content owner's infrastructure.
 
 `content_engaged` events are usually reported by the agent for in-product interactions. For a click-out to a landing page, a downstream marketplace, affiliate network, or destination site MAY report a corroborating `content_engaged` event using `ctx_token` in place of `session_id` (section 7.1).
 
@@ -324,6 +324,10 @@ Format: the URL of a manifest served at `/.well-known/content-telemetry.json` un
 | `type` | EventType | Yes | Event type (see 5.3) |
 | `timestamp` | datetime | Yes | Event timestamp (UTC) |
 | `turn_id` | string | No | Associates this event with a conversation turn (see 5.2.1) |
+| `output_id` | string | For cited/presented | Opaque output-artifact identifier joining construction to later delivery |
+| `output_element_id` | string | No | Opaque element within `output_id`, such as a passage, media track, caption, link, or card |
+| `citation_id` | UUID | No | On `content_presented`, the `id` of the associated citation event; absent for uncited presentations |
+| `presentation_id` | UUID | For engaged | On `content_engaged`, the `id` of the exact presentation occurrence acted upon |
 | `source_role` | SourceRole | No | Who is reporting: `origin`, `edge`, `index`, `agent` (see 4.4) |
 | `content_telemetry_id` | UUID | No | Correlation ID for cross-observer deduplication (see 7.2) |
 | `content_url` | string | No | Content URL as fetched or canonical URL |
@@ -334,7 +338,7 @@ Format: the URL of a manifest served at `/.well-known/content-telemetry.json` un
 
 #### 5.2.1 Turn association
 
-The `turn_id` field associates content events with a specific conversation turn. Emitters SHOULD set `turn_id` on `content_cited`, `content_displayed`, and `content_engaged` events. Emitters SHOULD also set `turn_id` on `content_grounded` events when `scope` is `turn`. The corresponding `turn_started` and `turn_completed` events SHOULD carry the same `turn_id`.
+The `turn_id` field associates content events with a specific conversation turn. Emitters SHOULD set `turn_id` on `content_cited`, `content_presented`, and `content_engaged` events. Emitters SHOULD also set `turn_id` on `content_grounded` events when `scope` is `turn`. The corresponding `turn_started` and `turn_completed` events SHOULD carry the same `turn_id`.
 
 `turn_id` is scoped to the session. Format is emitter-defined (sequential integers, UUIDs, or any opaque string).
 
@@ -356,9 +360,9 @@ The `license_ref` field connects a telemetry event to the content access licence
 |------|-------------|-----------------|
 | `content_retrieved` | Content fetched from source | `content_url`, `source_role`, `data.media_type` |
 | `content_grounded` | Content loaded into agent context | `content_url` or `content_id`, `data.scope`, `data.cached` |
-| `content_cited` | Content referenced in response | `content_url`, `data.citation_type`, `data.position` |
-| `content_displayed` | Content or a reference to it shown to user | `content_url`, `data.display_type` |
-| `content_engaged` | User acted on content | `content_url`, `data.engagement_type` (see 6.7) |
+| `content_cited` | Output explicitly associates source content with an output element | `id`, `output_id`, `content_url` or `content_id`, `data.citation_type` |
+| `content_presented` | Content or a source reference was made perceivable | `id`, `output_id`, `content_url` or `content_id`, `data.presentation_kind`, `data.presentation_type` |
+| `content_engaged` | Observable action on an exact presentation | `presentation_id`, `content_url` or `content_id`, `data.engagement_type` (see 6.7) |
 
 #### Conversation events
 
@@ -389,7 +393,7 @@ A conversation turn represents one query-response exchange. Turn data is carried
 | `query_tokens` | integer | No | Query token count |
 | `response_tokens` | integer | No | Response token count |
 | `model_id` | string | No | Model identifier |
-| `ad_rendered` | boolean | No | Whether advertising was displayed alongside the response |
+| `ad_rendered` | boolean | No | Whether advertising was rendered alongside the response |
 
 #### 5.4.1 Response modes
 
@@ -449,7 +453,7 @@ Each level is named for the event it adds: a level proves the emitter produces t
 | **Grounding** | Above + `content_grounded`, turn events | Content entered the agent's context | Agent with basic instrumentation |
 | **Citation** | Above + `content_cited` | Content was explicitly referenced in the agent's response | Agent with citation instrumentation |
 
-Display and engagement events are optional lifecycle signals. A Citation emitter SHOULD emit them when applicable (section 5.7.3), but the Citation level proves citation support, not full retrieval-to-engagement coverage.
+Presentation and engagement events are optional lifecycle signals. A Citation emitter SHOULD emit them when applicable (section 5.7.3), but the Citation level proves citation support, not full retrieval-to-engagement coverage.
 
 #### 5.7.1 Retrieval conformance
 
@@ -481,15 +485,16 @@ Emitters using standalone event delivery (section 7.1) MUST include `agent_id`, 
 
 A conforming **Citation** emitter MUST satisfy Grounding requirements and also:
 
-- Emit `content_cited` events with `data.citation_type`
+- Emit `content_cited` events with `id`, `output_id`, and `data.citation_type`
 
 The privacy-level field restriction (section 5.5) applies to Citation emitters as it does to any emitter producing conversation turns; it is inherited through the Grounding requirements above.
 
 A Citation emitter SHOULD:
 
-- Emit `content_displayed` and `content_engaged` events when applicable
+- Emit `content_presented` and `content_engaged` events when applicable
 - Include `data.position` on citation events
-- Include `data.display_type` on display events
+- Include `output_element_id` when the cited or presented element has a stable identity
+- Include `citation_id` on a presentation of a cited source association
 
 #### 5.7.4 Telemetry consumers
 
@@ -653,14 +658,17 @@ The `unclassified` value for `citation_type` indicates the agent did not classif
 
 When `content_hash` is absent or does not match any grounding event's hash (for example, because the agent re-chunked content between grounding and citation), consumers SHOULD fall back to matching on `content_url` or `content_id`, accepting that the correlation may be imprecise when the same content appears in multiple grounding events.
 
-### 6.6 Display data (`content_displayed`)
+### 6.6 Presentation data (`content_presented`)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `display_type` | string | How the content or a reference to it was presented (see below) |
-| `media_type` | string | Content medium: `text`, `image`, `video`, `audio` (open vocabulary, see 6.1). Defaults to `text` when absent. Most useful on `embed` displays (an embedded video reports `media_type: video`). |
+| `presentation_kind` | string | What was made perceivable: `content` or `source_reference` |
+| `presentation_type` | string | How it was made perceivable (see below) |
+| `media_type` | string | Medium made perceivable: `text`, `image`, `video`, `audio` (open vocabulary, see 6.1). Defaults to `text` when absent. |
 
-#### Display types
+`presentation_kind: content` means source content itself, a bounded excerpt, or a derived representation was made perceivable. It does not claim that the whole source was reproduced. `presentation_kind: source_reference` means a credit, identifier, link, card, or other reference to the source was made perceivable. This distinction is independent of modality: a spoken credit is a source reference; played source audio is content.
+
+#### Presentation types
 
 | Value | Description |
 |-------|-------------|
@@ -670,12 +678,15 @@ When `content_hash` is absent or does not match any grounding event's hash (for 
 | `card` | Rich preview card (title, description, image) |
 | `detail_view` | Expanded or full-content presentation within the agent's own interface |
 | `embed` | Source content rendered in the response surface: an iframe, a page rendered by an agentic browser, an embedded media player |
+| `spoken_credit` | Source reference spoken in an audio output or assistive surface |
 
-The first five values present a reference or excerpt within the agent's interface; `embed` presents the source content itself. An `embed` display can occur without a grounding event when the content never entered a generation context (section 4.3, *Departures from the funnel model*).
+`presentation_kind`, rather than `presentation_type`, determines whether the occurrence carries source content or a source reference. For example, a snippet may be an attributed source reference or an uncredited content excerpt. An embed can occur without a grounding event when the content never entered a generation context (section 4.3, *Departures from the funnel model*).
 
-These are the core values. Platforms with additional presentation surfaces MAY use custom string values. Telemetry consumers MUST tolerate unknown `display_type` values.
+These are the core values. Platforms with additional presentation surfaces MAY use custom string values. Telemetry consumers MUST tolerate unknown `presentation_type` values.
 
-When a session includes `content_displayed` events but no subsequent `content_engaged` events, the user saw a content reference but did not interact with it. Whether this pattern is meaningful depends on the commercial agreement - a per-citation deal may not care about clickthrough, while a traffic-based deal will. This pattern is only detectable from platform-reported `content_displayed` and `content_engaged` events. Retrieval is the only event stage observable from the CDN edge.
+Each presentation event MUST have an `id` and `output_id`. When it presents a citation, `citation_id` references that `content_cited` event's `id`; an uncited presentation omits `citation_id`. Repeated presentations of the same source or output element receive distinct event IDs. This allows a later `content_engaged.presentation_id` to identify the exact surface occurrence rather than matching only by URL.
+
+When a session includes `content_presented` events but no subsequent `content_engaged` events, the telemetry establishes only that content or a reference was made perceivable and no reported interaction followed. It does not establish human attention. Whether this pattern is meaningful depends on the governing terms. Retrieval remains the only lifecycle stage observable from the CDN edge.
 
 ### 6.7 Engagement data (`content_engaged`)
 
@@ -683,7 +694,7 @@ When a session includes `content_displayed` events but no subsequent `content_en
 |-------|------|-------------|
 | `engagement_type` | string | Type of interaction (see below) |
 
-The content URL is identified by the event-level `content_url` field (section 5.2), not duplicated in `data`.
+The content URL is identified by the event-level `content_url` field (section 5.2), not duplicated in `data`. Every engagement MUST carry `presentation_id`, referencing the exact `content_presented.id` on which the action occurred. Matching on URL alone is insufficient because the same source reference can be presented more than once.
 
 #### Engagement types
 
@@ -699,7 +710,7 @@ These are the core values. Extensions MAY define additional engagement actions -
 
 `agent_navigate` is the agent-mediated counterpart of a click: the user reached the source through the agent rather than through a browser. Consumers measuring traffic SHOULD count it alongside `link_click`, distinguishing the two where the commercial agreement does.
 
-`link_click` is the primary signal for clickthrough rate calculation. Telemetry consumers can derive per-content-owner and aggregate clickthrough rates from the ratio of `link_click` engagements to `content_displayed` events for the same `content_url`.
+`link_click` is the primary signal for clickthrough rate calculation. Telemetry consumers can derive per-content-owner and aggregate clickthrough rates from `link_click` engagements and link presentations, joining each engagement through `presentation_id` rather than URL alone.
 
 A `link_click` or `agent_navigate` engagement reported from the landing page after a click-out crosses a trust boundary. Such events carry a `ctx_token` in place of `session_id`, which the telemetry consumer resolves to the originating session's click manifest (see section 7.1).
 
@@ -754,8 +765,10 @@ An event batch carries the same envelope fields with `"document_type": "event_ba
       "content_url": "https://www.ft.com/content/abc123"
     },
     {
+      "id": "770e8400-e29b-41d4-a716-446655440301",
       "type": "content_cited",
       "timestamp": "2026-01-15T10:30:04Z",
+      "output_id": "response:1",
       "source_role": "agent",
       "content_url": "https://www.ft.com/content/abc123"
     }
@@ -769,7 +782,7 @@ For origin-side emitters at Retrieval conformance level, `session_id` MAY be omi
 
 For `content_engaged` events emitted from a landing page after a click-out (typically by a content marketplace, affiliate network, or destination site), `session_id` MAY be replaced by a `ctx_token` field that carries an opaque click-token issued by the originating agent. Telemetry consumers resolve the token to the owning session. This lets a downstream observer report a corroborating engagement event without sharing the session UUID across trust boundaries. An event MUST carry either `session_id` or `ctx_token` at Grounding conformance and above.
 
-**ctx_token resolution.** A telemetry consumer that supports `ctx_token` resolution exposes, for a resolved token, the **click manifest**: the set of `content_grounded`, `content_cited`, and `content_displayed` events belonging to the resolved session, identifying every source that informed the response that produced the click. The manifest is gated by the resolved session's `privacy_level` and by consent. A consumer MUST return the manifest only when the issuing agent has opted in to sharing sessions via click tokens; when the agent opt-in is absent, the consumer MUST NOT disclose the manifest. Within a returned manifest, a source MUST appear only when its content owner has opted in to being visible in click-token lookups; the consumer MUST withhold the events of any content owner whose opt-in is absent while returning the remainder of the manifest. A resolution response MUST NOT include the resolved session's raw `session_id`: the token exists so that the session UUID never crosses the trust boundary, and a resolution response that returned it would undo that. The mechanism by which an agent and a content owner record these opt-ins is operator-defined; the consent gate is normative.
+**ctx_token resolution.** A telemetry consumer that supports `ctx_token` resolution exposes, for a resolved token, the **click manifest**: the set of `content_grounded`, `content_cited`, and `content_presented` events belonging to the resolved session, identifying every source that informed the response that produced the click. The manifest is gated by the resolved session's `privacy_level` and by consent. A consumer MUST return the manifest only when the issuing agent has opted in to sharing sessions via click tokens; when the agent opt-in is absent, the consumer MUST NOT disclose the manifest. Within a returned manifest, a source MUST appear only when its content owner has opted in to being visible in click-token lookups; the consumer MUST withhold the events of any content owner whose opt-in is absent while returning the remainder of the manifest. A resolution response MUST NOT include the resolved session's raw `session_id`: the token exists so that the session UUID never crosses the trust boundary, and a resolution response that returned it would undo that. The mechanism by which an agent and a content owner record these opt-ins is operator-defined; the consent gate is normative.
 
 The primary schema (`telemetry-session.json`) validates session documents. A standalone event envelope schema (`telemetry-event.json`) validates the event delivery format, and a batch envelope schema (`telemetry-event-batch.json`) validates the event batch format. All three schemas share the `TelemetryEvent` definition.
 
@@ -873,7 +886,7 @@ A manifest MAY declare multiple roles (e.g. `["content_owner", "agent"]`). A mor
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Display name of the operating organisation. |
+| `name` | string | Yes | Presentation name of the operating organisation. |
 | `domain` | string | No | Primary domain. Defaults to the manifest URL's host. |
 
 ### 8.4 Keys
@@ -1063,7 +1076,7 @@ Content can influence every response in a session without being explicitly cited
 
 - At the **grounding** level: counts all content that was in the agent's context, regardless of citation. This captures the full extent of content influence, including silent grounding.
 - At the **citation** level: counts only explicitly attributed content. Simpler to verify but undercounts content influence.
-- At the **display** level: counts only content references shown to users. Narrowest scope, highest confidence.
+- At the **presentation** level: counts content or source references made perceivable. It does not prove attention.
 
 Content owners and platforms should agree on which level to count at. The telemetry data supports all three; the choice is commercial, not technical.
 
@@ -1126,6 +1139,23 @@ Telemetry consumers MUST tolerate unknown `response_mode` values.
 
 ## 12. Versioning
 
+### 12.1 Migration from the v0.1 preview
+
+V1 replaces `content_displayed` with `content_presented`; emitters MUST NOT send
+the old event name on the v1 integration line. Rename `data.display_type` to
+`data.presentation_type` and add `data.presentation_kind` with either `content`
+or `source_reference`. This is an intentional pre-1.0 breaking change: merely
+renaming the event would preserve the visual-only ambiguity and would not say
+what crossed the presentation boundary.
+
+For every `content_cited` event, assign an event `id` and `output_id`. For every
+`content_presented` event, assign a distinct event `id` and the `output_id` of the
+artifact made perceivable; add `output_element_id` when a stable element identity
+exists and `citation_id` when the presentation carries a citation. For every
+`content_engaged` event, add `presentation_id` referencing the exact presentation
+event. Do not migrate clicks by matching URL alone: repeated presentations of the
+same URL are distinct occurrences.
+
 Preview versions (0.x) use two-component version numbers. From 1.0.0 onward, versions follow [semantic versioning](https://semver.org/):
 
 - **Major** (1.0.0 → 2.0.0) - breaking changes to required fields
@@ -1186,9 +1216,12 @@ A user asks a shopping assistant to compare noise-cancelling headphones. The age
       }
     },
     {
+      "id": "770e8400-e29b-41d4-a716-446655440302",
       "type": "content_cited",
       "timestamp": "2026-01-15T10:30:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:recommendation:1",
       "content_url": "https://www.wirecutter.com/reviews/best-wireless-headphones",
       "content_id": "wirecutter:best-wireless-headphones-2026",
       "data": {
@@ -1198,13 +1231,18 @@ A user asks a shopping assistant to compare noise-cancelling headphones. The age
       }
     },
     {
-      "type": "content_displayed",
+      "id": "770e8400-e29b-41d4-a716-446655440303",
+      "type": "content_presented",
       "timestamp": "2026-01-15T10:30:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:recommendation:1",
+      "citation_id": "770e8400-e29b-41d4-a716-446655440302",
       "content_url": "https://www.wirecutter.com/reviews/best-wireless-headphones",
       "content_id": "wirecutter:best-wireless-headphones-2026",
       "data": {
-        "display_type": "link"
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
       }
     },
     {
@@ -1230,6 +1268,7 @@ A user asks a shopping assistant to compare noise-cancelling headphones. The age
       "type": "content_engaged",
       "timestamp": "2026-01-15T10:32:00Z",
       "turn_id": "1",
+      "presentation_id": "770e8400-e29b-41d4-a716-446655440303",
       "content_url": "https://www.wirecutter.com/reviews/best-wireless-headphones",
       "content_id": "wirecutter:best-wireless-headphones-2026",
       "data": {
@@ -1321,9 +1360,12 @@ An AI agent previously fetched an FT article and cached it. In a new session, th
       }
     },
     {
+      "id": "770e8400-e29b-41d4-a716-446655440304",
       "type": "content_cited",
       "timestamp": "2026-03-28T09:00:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:paragraph:2",
       "content_url": "https://www.ft.com/content/abc123",
       "content_id": "ft:abc123",
       "data": {
@@ -1335,13 +1377,18 @@ An AI agent previously fetched an FT article and cached it. In a new session, th
       }
     },
     {
-      "type": "content_displayed",
+      "id": "770e8400-e29b-41d4-a716-446655440305",
+      "type": "content_presented",
       "timestamp": "2026-03-28T09:00:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:paragraph:2",
+      "citation_id": "770e8400-e29b-41d4-a716-446655440304",
       "content_url": "https://www.ft.com/content/abc123",
       "content_id": "ft:abc123",
       "data": {
-        "display_type": "link"
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
       }
     },
     {
@@ -1368,9 +1415,11 @@ An AI agent previously fetched an FT article and cached it. In a new session, th
       }
     },
     {
+      "id": "770e8400-e29b-41d4-a716-446655440306",
       "type": "content_cited",
       "timestamp": "2026-03-28T09:01:08Z",
       "turn_id": "2",
+      "output_id": "response:2",
       "content_url": "https://www.ft.com/content/abc123",
       "content_id": "ft:abc123",
       "data": {
@@ -1420,11 +1469,11 @@ In this session:
 - 1 article grounded from cache (no `content_retrieved` event - the CDN saw nothing)
 - 3 turns of conversation
 - 2 explicit citations (turns 1 and 2)
-- 1 display event (link shown in turn 1)
-- 0 engagement events (user did not click through to ft.com)
+- 1 presentation event (link made perceivable in turn 1)
+- 0 engagement events (no click-through was reported)
 - Advertising was rendered alongside the first response
 
-The content owner can derive: article `ft:abc123` was in context for all turns, cited twice, displayed once, never clicked. The content was 14.5 hours old (cached from previous day). The response was monetised with advertising.
+The content owner can derive: article `ft:abc123` was in context for all turns, cited twice, presented once, and had no reported engagement. The content was 14.5 hours old (cached from previous day). The response was monetised with advertising.
 
 ### B.4 Minimal privacy level
 

--- a/telemetry-session.json
+++ b/telemetry-session.json
@@ -78,7 +78,27 @@
         },
         "turn_id": {
           "type": ["string", "null"],
-          "description": "Associates this event with a conversation turn. Scoped to the session. SHOULD be set on turn_started, turn_completed, content_cited, content_displayed, content_engaged events, and content_grounded events when scope is turn."
+          "description": "Associates this event with a conversation turn. Scoped to the session. SHOULD be set on turn_started, turn_completed, content_cited, content_presented, content_engaged events, and content_grounded events when scope is turn."
+        },
+        "output_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Opaque identifier for the output artifact. REQUIRED on content_cited and content_presented events so output construction and later presentation can be correlated across services or times."
+        },
+        "output_element_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Opaque identifier for the element within output_id that carries the citation or presentation, such as a passage, media track, caption, link, or card."
+        },
+        "citation_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The id of the content_cited event associated with this presentation. Valid only on content_presented events and absent when the presentation is not a citation."
+        },
+        "presentation_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The id of the exact content_presented event on which the engagement occurred. REQUIRED on content_engaged events."
         },
         "source_role": {
           "$ref": "#/$defs/SourceRole",
@@ -140,6 +160,7 @@
             "required": ["type"]
           },
           "then": {
+            "required": ["id", "output_id"],
             "properties": {
               "data": {
                 "properties": {
@@ -158,14 +179,17 @@
         },
         {
           "if": {
-            "properties": { "type": { "const": "content_displayed" } },
+            "properties": { "type": { "const": "content_presented" } },
             "required": ["type"]
           },
           "then": {
+            "required": ["id", "output_id", "data"],
             "properties": {
               "data": {
+                "required": ["presentation_kind", "presentation_type"],
                 "properties": {
-                  "display_type": { "$ref": "#/$defs/DisplayType" },
+                  "presentation_kind": { "$ref": "#/$defs/PresentationKind" },
+                  "presentation_type": { "$ref": "#/$defs/PresentationType" },
                   "media_type": { "$ref": "#/$defs/MediaType" }
                 }
               }
@@ -178,6 +202,7 @@
             "required": ["type"]
           },
           "then": {
+            "required": ["presentation_id"],
             "properties": {
               "data": {
                 "properties": {
@@ -223,7 +248,7 @@
         "content_retrieved",
         "content_grounded",
         "content_cited",
-        "content_displayed",
+        "content_presented",
         "content_engaged",
         "turn_started",
         "turn_completed"
@@ -334,9 +359,14 @@
       "description": "Whether content informed all subsequent responses in the session or a specific turn only",
       "enum": ["session", "turn"]
     },
-    "DisplayType": {
+    "PresentationKind": {
       "type": "string",
-      "description": "How content or a content reference was presented to the user. Core values: link, snippet, inline_quote, card, detail_view, embed. Platforms MAY use custom values for additional presentation surfaces. Consumers MUST tolerate unknown values."
+      "description": "What was made perceivable: source content itself, including a bounded excerpt or derived representation, or a reference to the source.",
+      "enum": ["content", "source_reference"]
+    },
+    "PresentationType": {
+      "type": "string",
+      "description": "How content or a source reference was made perceivable. Core values: link, snippet, inline_quote, card, detail_view, embed, spoken_credit. Platforms MAY use custom values for additional presentation surfaces. Consumers MUST tolerate unknown values."
     }
   }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,8 +31,9 @@ Run from the repository root. Without uv: `pip install jsonschema`, then `python
 - All three conformance levels (Retrieval, Grounding, Citation)
 - Standalone event envelopes (CDN edge, agent with session FK)
 - Privacy level field gating (application-layer conformance)
-- Funnel exceptions (displayed-no-cited, cited-no-grounded, displayed-no-grounded)
-- Embedded display (`display_type: embed`) and agent-mediated engagement (`agent_navigate`)
+- Funnel exceptions (presented-no-cited, cited-no-grounded, presented-no-grounded)
+- Text, image, audio, video, suppressed-citation, and repeated-presentation cases
+- Exact presentation-to-engagement correlation across session, standalone, and batch envelopes
 - Multi-turn sessions, cached grounding
 - Custom response_mode values
 

--- a/tests/invalid/batch-missing-session-and-ctx-token.json
+++ b/tests/invalid/batch-missing-session-and-ctx-token.json
@@ -4,8 +4,10 @@
   "schema_version": "0.1",
   "events": [
     {
+      "id": "990e8400-e29b-41d4-a716-446655440063",
       "type": "content_cited",
       "timestamp": "2026-03-28T10:05:00Z",
+      "output_id": "response:1",
       "source_role": "agent",
       "content_url": "https://example.com/article/test"
     }

--- a/tests/invalid/engaged-missing-presentation-id.json
+++ b/tests/invalid/engaged-missing-presentation-id.json
@@ -1,0 +1,14 @@
+{
+  "_test_description": "content_engaged must identify the exact presentation occurrence rather than matching only by URL.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440092",
+  "started_at": "2026-07-18T13:00:00Z",
+  "events": [
+    {
+      "type": "content_engaged",
+      "timestamp": "2026-07-18T13:00:02Z",
+      "content_id": "publisher:article:1",
+      "data": { "engagement_type": "link_click" }
+    }
+  ]
+}

--- a/tests/invalid/legacy-content-displayed.json
+++ b/tests/invalid/legacy-content-displayed.json
@@ -1,0 +1,14 @@
+{
+  "_test_description": "The v1 presentation event replaces the preview content_displayed name.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440093",
+  "started_at": "2026-07-18T13:00:00Z",
+  "events": [
+    {
+      "type": "content_displayed",
+      "timestamp": "2026-07-18T13:00:03Z",
+      "content_id": "publisher:article:1",
+      "data": { "display_type": "link" }
+    }
+  ]
+}

--- a/tests/invalid/presented-missing-kind.json
+++ b/tests/invalid/presented-missing-kind.json
@@ -1,0 +1,16 @@
+{
+  "_test_description": "content_presented must distinguish source content from a source reference.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440090",
+  "started_at": "2026-07-18T13:00:00Z",
+  "events": [
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440091",
+      "type": "content_presented",
+      "timestamp": "2026-07-18T13:00:01Z",
+      "output_id": "response:1",
+      "content_id": "publisher:article:1",
+      "data": { "presentation_type": "link" }
+    }
+  ]
+}

--- a/tests/valid/event-batch-agent.json
+++ b/tests/valid/event-batch-agent.json
@@ -20,10 +20,25 @@
       "content_url": "https://arstechnica.com/science/2026/03/new-battery-chemistry-breakthrough/"
     },
     {
+      "id": "990e8400-e29b-41d4-a716-446655440062",
       "type": "content_cited",
       "timestamp": "2026-03-28T08:20:05Z",
+      "output_id": "response:1",
       "source_role": "agent",
       "content_url": "https://arstechnica.com/science/2026/03/new-battery-chemistry-breakthrough/"
+    },
+    {
+      "id": "990e8400-e29b-41d4-a716-446655440063",
+      "type": "content_presented",
+      "timestamp": "2026-03-28T08:20:06Z",
+      "output_id": "response:1",
+      "citation_id": "990e8400-e29b-41d4-a716-446655440062",
+      "source_role": "agent",
+      "content_url": "https://arstechnica.com/science/2026/03/new-battery-chemistry-breakthrough/",
+      "data": {
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
+      }
     }
   ]
 }

--- a/tests/valid/event-standalone-engaged-ctx-token.json
+++ b/tests/valid/event-standalone-engaged-ctx-token.json
@@ -6,6 +6,7 @@
   "event": {
     "type": "content_engaged",
     "timestamp": "2026-03-28T14:06:00Z",
+    "presentation_id": "990e8400-e29b-41d4-a716-446655440064",
     "content_url": "https://www.example-review.com/headphones/best-noise-cancelling",
     "data": {
       "engagement_type": "link_click"

--- a/tests/valid/event-standalone-presented.json
+++ b/tests/valid/event-standalone-presented.json
@@ -1,0 +1,20 @@
+{
+  "_test_description": "Standalone presentation envelope using the shared modality-neutral presentation schema.",
+  "document_type": "event",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440080",
+  "agent_id": "voice-assistant-v1",
+  "started_at": "2026-07-18T12:30:00Z",
+  "event": {
+    "id": "770e8400-e29b-41d4-a716-446655440081",
+    "type": "content_presented",
+    "timestamp": "2026-07-18T12:30:05Z",
+    "output_id": "audio-response:1",
+    "content_id": "publisher:article:1",
+    "data": {
+      "presentation_kind": "source_reference",
+      "presentation_type": "spoken_credit",
+      "media_type": "audio"
+    }
+  }
+}

--- a/tests/valid/session-citation-tier.json
+++ b/tests/valid/session-citation-tier.json
@@ -41,9 +41,12 @@
       }
     },
     {
+      "id": "880e8400-e29b-41d4-a716-446655440011",
       "type": "content_cited",
       "timestamp": "2026-03-28T14:00:06Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:recommendation:1",
       "content_url": "https://www.runnersworld.com/gear/best-trail-running-shoes",
       "content_id": "rw:best-trail-shoes-2026",
       "data": {
@@ -56,13 +59,18 @@
       }
     },
     {
-      "type": "content_displayed",
+      "id": "880e8400-e29b-41d4-a716-446655440012",
+      "type": "content_presented",
       "timestamp": "2026-03-28T14:00:06Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:recommendation:1",
+      "citation_id": "880e8400-e29b-41d4-a716-446655440011",
       "content_url": "https://www.runnersworld.com/gear/best-trail-running-shoes",
       "content_id": "rw:best-trail-shoes-2026",
       "data": {
-        "display_type": "card"
+        "presentation_kind": "source_reference",
+        "presentation_type": "card"
       }
     },
     {
@@ -88,6 +96,7 @@
       "type": "content_engaged",
       "timestamp": "2026-03-28T14:02:30Z",
       "turn_id": "1",
+      "presentation_id": "880e8400-e29b-41d4-a716-446655440012",
       "content_url": "https://www.runnersworld.com/gear/best-trail-running-shoes",
       "content_id": "rw:best-trail-shoes-2026",
       "data": {

--- a/tests/valid/session-funnel-exception-cited-no-grounded.json
+++ b/tests/valid/session-funnel-exception-cited-no-grounded.json
@@ -16,9 +16,12 @@
       }
     },
     {
+      "id": "880e8400-e29b-41d4-a716-446655440021",
       "type": "content_cited",
       "timestamp": "2026-03-28T20:00:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:claim:1",
       "content_url": "https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration",
       "data": {
         "citation_type": "reference",
@@ -27,12 +30,17 @@
       }
     },
     {
-      "type": "content_displayed",
+      "id": "880e8400-e29b-41d4-a716-446655440022",
+      "type": "content_presented",
       "timestamp": "2026-03-28T20:00:05Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "answer:claim:1",
+      "citation_id": "880e8400-e29b-41d4-a716-446655440021",
       "content_url": "https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration",
       "data": {
-        "display_type": "link"
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
       }
     },
     {

--- a/tests/valid/session-funnel-exception-presented-no-cited.json
+++ b/tests/valid/session-funnel-exception-presented-no-cited.json
@@ -1,5 +1,5 @@
 {
-  "_test_description": "Funnel exception: content_displayed without content_cited. This is the Sources sidebar pattern - the agent shows source links without explicitly citing the content in the response text. Valid per section 4.3.",
+  "_test_description": "Funnel exception: content_presented without content_cited. This is the Sources sidebar pattern - the agent makes source links perceivable without semantically associating them with an output element. Valid per section 4.3.",
   "schema_version": "0.1",
   "session_id": "660e8400-e29b-41d4-a716-446655440010",
   "agent_id": "search-assistant-v1",
@@ -32,12 +32,16 @@
       }
     },
     {
-      "type": "content_displayed",
+      "id": "880e8400-e29b-41d4-a716-446655440031",
+      "type": "content_presented",
       "timestamp": "2026-03-28T19:00:06Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "output_element_id": "sources:1",
       "content_url": "https://www.kingarthurbaking.com/recipes/sourdough-starter-maintenance",
       "data": {
-        "display_type": "link"
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
       }
     },
     {

--- a/tests/valid/session-funnel-exception-presented-no-grounded.json
+++ b/tests/valid/session-funnel-exception-presented-no-grounded.json
@@ -1,5 +1,5 @@
 {
-  "_test_description": "Funnel exception: content_displayed without content_grounded. An agentic browser renders a publisher's page to the user (display_type: embed) without the content entering a generation context, and the user directs the agent to open a second page (engagement_type: agent_navigate). Valid per section 4.3. Also exercises media_type on display data and the open display_type/engagement_type vocabularies.",
+  "_test_description": "Funnel exception: content_presented without content_grounded. An agentic browser renders a publisher's page on a recipient-facing surface (presentation_type: embed) without the content entering a generation context, and the recipient directs the agent to open a second page (engagement_type: agent_navigate). Valid per section 4.3. Also exercises media_type on presentation data and the open presentation_type/engagement_type vocabularies.",
   "schema_version": "0.1",
   "session_id": "660e8400-e29b-41d4-a716-446655440020",
   "agent_id": "browser-agent-v1",
@@ -22,22 +22,28 @@
       "content_url": "https://www.fitnessmedia.example/guides/home-workouts"
     },
     {
-      "type": "content_displayed",
+      "id": "880e8400-e29b-41d4-a716-446655440041",
+      "type": "content_presented",
       "timestamp": "2026-03-29T11:00:02Z",
       "turn_id": "1",
+      "output_id": "browser-view:1",
       "content_url": "https://www.fitnessmedia.example/guides/home-workouts",
       "data": {
-        "display_type": "embed",
+        "presentation_kind": "content",
+        "presentation_type": "embed",
         "media_type": "text"
       }
     },
     {
-      "type": "content_displayed",
+      "id": "880e8400-e29b-41d4-a716-446655440042",
+      "type": "content_presented",
       "timestamp": "2026-03-29T11:00:04Z",
       "turn_id": "1",
+      "output_id": "browser-view:1",
       "content_url": "https://www.fitnessmedia.example/videos/beginner-routine",
       "data": {
-        "display_type": "embed",
+        "presentation_kind": "content",
+        "presentation_type": "embed",
         "media_type": "video"
       }
     },
@@ -56,6 +62,7 @@
       "type": "content_engaged",
       "timestamp": "2026-03-29T11:01:00Z",
       "turn_id": "1",
+      "presentation_id": "880e8400-e29b-41d4-a716-446655440041",
       "content_url": "https://www.fitnessmedia.example/guides/home-workouts",
       "data": {
         "engagement_type": "agent_navigate"

--- a/tests/valid/session-multi-turn.json
+++ b/tests/valid/session-multi-turn.json
@@ -35,9 +35,11 @@
       }
     },
     {
+      "id": "880e8400-e29b-41d4-a716-446655440051",
       "type": "content_cited",
       "timestamp": "2026-03-28T16:00:08Z",
       "turn_id": "1",
+      "output_id": "response:1",
       "content_url": "https://www.bbc.co.uk/news/science-environment-68234567",
       "content_id": "bbc:68234567",
       "data": {
@@ -47,12 +49,16 @@
       }
     },
     {
-      "type": "content_displayed",
+      "id": "880e8400-e29b-41d4-a716-446655440052",
+      "type": "content_presented",
       "timestamp": "2026-03-28T16:00:08Z",
       "turn_id": "1",
+      "output_id": "response:1",
+      "citation_id": "880e8400-e29b-41d4-a716-446655440051",
       "content_url": "https://www.bbc.co.uk/news/science-environment-68234567",
       "data": {
-        "display_type": "link"
+        "presentation_kind": "source_reference",
+        "presentation_type": "link"
       }
     },
     {
@@ -100,9 +106,11 @@
       }
     },
     {
+      "id": "880e8400-e29b-41d4-a716-446655440053",
       "type": "content_cited",
       "timestamp": "2026-03-28T16:05:12Z",
       "turn_id": "3",
+      "output_id": "response:3",
       "content_url": "https://www.bbc.co.uk/news/science-environment-68234567",
       "content_id": "bbc:68234567",
       "data": {

--- a/tests/valid/session-presentation-multimodal.json
+++ b/tests/valid/session-presentation-multimodal.json
@@ -1,0 +1,96 @@
+{
+  "_test_description": "Modality-neutral citation and presentation: an image excerpt is presented as content, an audio output speaks a source credit, a video is embedded without citation, a constructed citation is suppressed, and a repeated link presentation receives the engagement.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440070",
+  "agent_id": "multimodal-assistant-v1",
+  "started_at": "2026-07-18T12:00:00Z",
+  "events": [
+    {
+      "type": "content_grounded",
+      "timestamp": "2026-07-18T12:00:01Z",
+      "content_id": "museum:image:42",
+      "data": { "scope": "turn", "cached": true, "media_type": "image" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440071",
+      "type": "content_cited",
+      "timestamp": "2026-07-18T12:00:04Z",
+      "turn_id": "1",
+      "output_id": "output:mixed:1",
+      "output_element_id": "image:region:credit",
+      "content_id": "museum:image:42",
+      "data": { "citation_type": "reference", "media_type": "image" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440072",
+      "type": "content_presented",
+      "timestamp": "2026-07-18T12:00:05Z",
+      "turn_id": "1",
+      "output_id": "output:mixed:1",
+      "output_element_id": "image:region:1",
+      "content_id": "museum:image:42",
+      "data": { "presentation_kind": "content", "presentation_type": "embed", "media_type": "image" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440073",
+      "type": "content_presented",
+      "timestamp": "2026-07-18T12:00:06Z",
+      "turn_id": "1",
+      "output_id": "output:mixed:1",
+      "output_element_id": "audio:credit:1",
+      "citation_id": "770e8400-e29b-41d4-a716-446655440071",
+      "content_id": "museum:image:42",
+      "data": { "presentation_kind": "source_reference", "presentation_type": "spoken_credit", "media_type": "audio" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440074",
+      "type": "content_presented",
+      "timestamp": "2026-07-18T12:00:07Z",
+      "turn_id": "1",
+      "output_id": "output:mixed:1",
+      "output_element_id": "video:1",
+      "content_id": "archive:video:7",
+      "data": { "presentation_kind": "content", "presentation_type": "embed", "media_type": "video" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440075",
+      "type": "content_cited",
+      "timestamp": "2026-07-18T12:00:08Z",
+      "turn_id": "1",
+      "output_id": "output:suppressed:1",
+      "output_element_id": "caption:1",
+      "content_id": "audio:interview:9",
+      "data": { "citation_type": "reference", "media_type": "audio" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440076",
+      "type": "content_presented",
+      "timestamp": "2026-07-18T12:00:09Z",
+      "turn_id": "1",
+      "output_id": "output:mixed:1",
+      "output_element_id": "sources:link:1",
+      "citation_id": "770e8400-e29b-41d4-a716-446655440071",
+      "content_id": "museum:image:42",
+      "data": { "presentation_kind": "source_reference", "presentation_type": "link", "media_type": "text" }
+    },
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440077",
+      "type": "content_presented",
+      "timestamp": "2026-07-18T12:00:10Z",
+      "turn_id": "1",
+      "output_id": "output:mixed:1",
+      "output_element_id": "sidebar:link:1",
+      "citation_id": "770e8400-e29b-41d4-a716-446655440071",
+      "content_id": "museum:image:42",
+      "data": { "presentation_kind": "source_reference", "presentation_type": "link", "media_type": "text" }
+    },
+    {
+      "type": "content_engaged",
+      "timestamp": "2026-07-18T12:00:12Z",
+      "turn_id": "1",
+      "presentation_id": "770e8400-e29b-41d4-a716-446655440077",
+      "content_id": "museum:image:42",
+      "data": { "engagement_type": "link_click" }
+    }
+  ]
+}

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -103,7 +103,7 @@ APPLICATION_LAYER_VIOLATIONS = {
 # turn_completed are turn events, not content events, and are exempt.
 CONTENT_EVENT_TYPES = {
     "content_retrieved", "content_grounded", "content_cited",
-    "content_displayed", "content_engaged",
+    "content_presented", "content_engaged",
 }
 
 # Fields that MUST NOT appear at each privacy level (section 5.5).


### PR DESCRIPTION
Implements the settled presentation boundary from #14 and establishes the correlation vocabulary needed by #25.

- renames `content_displayed` to `content_presented`
- distinguishes presentation of source `content` from a `source_reference`
- adds `output_id` / `output_element_id`, citation-to-presentation correlation, and exact presentation-to-engagement correlation
- documents the pre-v1 migration
- adds text, image, audio, video, suppressed-citation, repeated-presentation, standalone, batch, valid, and invalid fixtures

This PR intentionally does not attempt the remaining multimodal representation and bounded-portion design in #25.

Tests:
- `uv run --with jsonschema python tests/validate.py` (55/55)
- `uv run --with jsonschema python tests/check_examples.py` (9/9)
- `git diff --check`

Closes the settled implementation portion of #14; does not close #25.