### PR TITLE
Adopt a human-written proposal workflow for new capabilities

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/spec-feedback.yml
@@ -1,5 +1,5 @@
 name: Spec feedback / open question
-description: Raise a design question, an unclear requirement, or a proposed change to the wire format.
+description: Raise a question, ambiguity, or unclear requirement in the wire format.
 title: "[spec] "
 labels: ["needs-discussion"]
 body:
@@ -7,8 +7,12 @@ body:
     attributes:
       value: |
         Thanks for reviewing the Content Telemetry standard. This template is for
-        feedback on the specification itself - design questions, unclear or
-        contradictory requirements, gaps, or proposed changes to the wire format.
+        questions, unclear or contradictory requirements, and gaps in the
+        specification as written.
+
+        For a new capability or change in behaviour, submit a short human-written
+        note to [proposals/](../tree/main/proposals) instead. Please wait for
+        explicit maintainer alignment before beginning implementation.
 
         For a concrete bug in a schema file or a worked example, use the
         **Schema or example bug** template instead.
@@ -37,13 +41,6 @@ body:
     attributes:
       label: Why it matters
       description: What breaks, stays unclear, or gets implemented inconsistently if this isn't resolved? A real implementation scenario helps most.
-    validations:
-      required: false
-  - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed direction (optional)
-      description: If you have one. A rough sketch is fine - you don't need a finished PR.
     validations:
       required: false
   - type: dropdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,59 @@ This repo contains the **specification** - the data model, event types, privacy 
 
 ## Proposing changes
 
-Schema changes affect all implementations. Before submitting a PR:
+We would like proposals for new capabilities or changes in behaviour to begin
+with the people who need them, not with generated specification text or code.
 
-1. Open an issue describing the change and its motivation
-2. Reference the relevant section of SPECIFICATION.md
-3. Consider backwards compatibility - can existing consumers ignore new fields?
-4. Update both SPECIFICATION.md and the relevant JSON schema
-5. Add or update test cases in `tests/` for any new fields or conformance rules
-6. Run the test suite to verify everything passes (see below)
+Submit a pull request adding a short Markdown or text file to
+[`proposals/`](./proposals/). Write it as you would explain the idea to a
+colleague: what you are seeing, what you would like Content Telemetry to
+express, and why it matters. It can be informal. Please do not ask an AI agent
+to expand the idea into a formal proposal or implementation for us.
+
+A proposal starts a discussion. It is not an accepted change, an item on the
+maintainers' implementation backlog, or a commitment to spend time or tokens on
+it. We will first consider whether the proposal:
+
+- belongs in the Content Telemetry wire format rather than a profile,
+  deployment or application;
+- addresses a need shared beyond one implementation;
+- fits the scope and direction of the standard; and
+- can evolve the standard without unacceptable compatibility costs.
+
+A maintainer will explicitly mark a proposal **aligned** if there is agreement
+on the direction. That is the gate for substantial implementation work. Please
+wait for it before asking an agent to implement the proposal or opening a pull
+request that changes the specification, schemas or tests.
+
+Alignment is not final acceptance of every detail. Maintainers may work with
+the proposer to prepare the specification text, schema changes, examples and
+tests, and material changes will be discussed with them. Acceptance remains
+subject to the project's governance, compatibility and review requirements.
+The proposer will be credited as a co-author when their proposal is
+implemented.
+
+See the [`proposals/` README](./proposals/README.md) for proposal statuses and
+the small amount of information to include.
+
+## Bugs and security vulnerabilities
+
+For concrete schema, example or documentation bugs, open an issue using the
+**Schema or example bug** template. A bug fix does not need a proposal first.
+
+Report security vulnerabilities privately as described in
+[`SECURITY.md`](./SECURITY.md), not in an issue or public proposal.
+
+## Implementing an aligned proposal
+
+Schema changes affect all implementations. Once a proposal is aligned, an
+implementation pull request should:
+
+1. Link to the aligned proposal.
+2. Reference the relevant section of SPECIFICATION.md.
+3. Address backwards compatibility - can existing consumers ignore new fields?
+4. Update both SPECIFICATION.md and the relevant JSON schema.
+5. Add or update test cases in `tests/` for any new fields or conformance rules.
+6. Run the test suite to verify everything passes (see below).
 
 ## Running the tests
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,9 +28,11 @@ The specification is at v0.1 (preview). It moves to 1.0 once the open questions 
 
 ## How to participate
 
-- File feedback, questions, and bugs on the [issue tracker](https://github.com/SPUR-Coalition/telemetry/issues) (see the templates).
+- File questions and bugs on the [issue tracker](https://github.com/SPUR-Coalition/telemetry/issues) (see the templates).
 - Comment during the [public comment window](./README.md#request-for-comment).
-- Propose specific changes by pull request, following [CONTRIBUTING.md](./CONTRIBUTING.md).
+- Propose new capabilities or changes in behaviour as a short human-written note
+  in [`proposals/`](./proposals/), following
+  [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Relationship to the SPUR Content Telemetry Profile
 
@@ -42,7 +44,10 @@ The dependency runs one way. The profile references the standard; the standard d
 
 ## Changes to the specification
 
-Specification changes follow the process in [CONTRIBUTING.md](./CONTRIBUTING.md). Required-field and conformance-level changes are breaking and follow the versioning policy in SPECIFICATION.md section 12.
+Specification changes follow the proposal and maintainer-alignment process in
+[CONTRIBUTING.md](./CONTRIBUTING.md). Required-field and conformance-level
+changes are breaking and follow the versioning policy in SPECIFICATION.md
+section 12.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,14 @@ Comment is most useful on:
 - Anything that would require an implementer to depend on a particular operator or service to participate. The standard should be implementable from the public schemas alone.
 - Any worked example that does not validate against its schema, or any mismatch between the prose and the schemas.
 
-File an issue on this repository using the available templates: *Spec feedback / open question* for design questions and proposed changes, and *Schema or example bug* for concrete defects. Pull requests are welcome for specific schema or text fixes; for larger changes, open an issue first (see [CONTRIBUTING.md](./CONTRIBUTING.md)). Feedback on accreditation, the Compliant tier, or the conformance mark belongs on the [profile repository](https://github.com/SPUR-Coalition/telemetry-profile/issues).
+File an issue on this repository using the available templates: *Spec feedback
+/ open question* for questions or unclear requirements, and *Schema or example
+bug* for concrete defects. For a new capability or change in behaviour, submit
+a short human-written note to [`proposals/`](./proposals/) and wait for explicit
+maintainer alignment before beginning implementation (see
+[CONTRIBUTING.md](./CONTRIBUTING.md)). Feedback on accreditation, the Compliant
+tier, or the conformance mark belongs on the [profile
+repository](https://github.com/SPUR-Coalition/telemetry-profile/issues).
 
 Some areas are out of scope for this round. The non-goals are in [section 1.3](./SPECIFICATION.md#13-non-goals) and the deferred manifest features in [section 8.9](./SPECIFICATION.md#89-out-of-scope-for-v01); please read those before filing. Comments on whether a non-goal is the right call are welcome, provided they say which one and why.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+Please do not report security vulnerabilities in a public issue, proposal or
+pull request.
+
+Report them privately to Alex Springer at alex@spurcoalition.org. Include the
+affected component or specification section, the potential impact and enough
+detail to reproduce or assess the problem. Please avoid including personal
+data, credentials or other secrets unless they are necessary to understand the
+report.
+
+We will acknowledge the report and coordinate disclosure and remediation with
+you before publishing details.

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,35 @@
+# Proposals
+
+This directory is for human-written proposals for new capabilities or changes
+in Content Telemetry's behaviour.
+
+A proposal can be informal. In a short Markdown or text file, tell us:
+
+- what you are seeing;
+- what you would like Content Telemetry to express; and
+- why it matters to you or other implementers.
+
+Write it as you would explain the idea to a colleague. Please do not ask an AI
+agent to turn it into formal specification language or implement it before the
+maintainers have confirmed alignment.
+
+## Statuses
+
+Every proposal has one of these statuses:
+
+- **Discussing** - the initial status; no implementation commitment has been
+  made.
+- **Aligned** - a maintainer has confirmed agreement on the direction;
+  substantial implementation work may begin.
+- **Declined** - the proposal will not be pursued, with the reason recorded.
+- **Implemented** - the resulting normative changes and tests have landed.
+
+Add `Status: discussing` near the top of a new proposal. Only a maintainer may
+change its status. Alignment is the gate for implementation, not a guarantee
+that every detail will be accepted unchanged.
+
+Proposals that do not reach alignment may be closed or archived so that this
+directory does not become an ambiguous implementation backlog.
+
+Concrete bugs belong in the issue tracker. Security vulnerabilities must be
+reported privately as described in [`SECURITY.md`](../SECURITY.md).


### PR DESCRIPTION
Adds a lightweight proposal stage in front of specification changes, following the pattern used during the consultation:

- New capabilities or behaviour changes start as a short human-written note in `proposals/`, not as generated spec text or an unsolicited schema PR.
- A maintainer marks a proposal **aligned** before substantial implementation work begins; alignment is the gate, not final acceptance.
- The spec-feedback issue template narrows to questions, ambiguities and gaps; the proposal route is signposted from the template, README, GOVERNANCE and SECURITY.
- Bug fixes and security reports keep their existing direct routes.

Documentation only; no schema or normative specification changes.