### PR TITLE
Complete v1 grounding provenance and fingerprint semantics

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -560,6 +560,8 @@ The JSON Schema (`telemetry-session.json`) validates structure and types but can
 - An event MUST carry either `session_id` or `ctx_token` at Grounding conformance and above (section 7.1).
 - Conversation-turn fields MUST NOT exceed the turn's declared `privacy_level` (section 5.5).
 - The conformance-level requirements (sections 5.7.1 to 5.7.3) are cumulative.
+- When `content_grounded.data.provenance` is `agent_fetched`, `data.cached` MUST be `false`; when it is `agent_cached`, `data.cached` MUST be `true` (section 6.4).
+- `content_grounded.data.content_fingerprint` MUST NOT contain `preserved_in_output`; output-side reuse is reported with `content_reproduced` (sections 6.4 and 12.1).
 
 The `tests/` directory provides an informative reference suite for these rules. A consumer that receives a privacy-violating turn (e.g., `query_text` present at `minimal` level) SHOULD strip the offending fields rather than reject the document carrying them.
 
@@ -624,18 +626,48 @@ Emitting a `training`-category `content_retrieved` event is permitted but non-at
 |-------|------|-------------|
 | `scope` | string | Influence scope: `session` or `turn` (see below) |
 | `cached` | boolean | Content served from agent-side cache rather than a live fetch |
+| `provenance` | string | How content reached the context: `agent_fetched`, `agent_cached`, or `third_party_sourced` (see below) |
 | `chars_ingested` | integer | Character count of content placed in the generation context (see below) |
 | `tokens_ingested` | integer | Token count of the same content, supplementary (see below) |
 | `content_version` | string | Content version identifier (ETag, revision ID, CMS version) |
 | `content_last_modified` | datetime | When the content was last modified at source |
 | `content_hash` | string | SHA-256 of the content as ingested (`sha256:{hex}`) |
 | `media_type` | string | Content medium: `text`, `image`, `video`, `audio` (open vocabulary, see 6.1) |
+| `content_fingerprint` | object | Agent-reported detection of a fingerprint or provenance signal in the grounded content (see below) |
 
 Both fields measure the content actually placed in the generation model's context. For chunked retrieval, count only the portion used, not the full source document.
 
 `chars_ingested` counts Unicode code points in the exact text placed in context. Count the string as ingested: an emitter MUST NOT apply Unicode normalisation solely to calculate this field. It is the portable measure: two emitters that ingest the same code-point sequence agree, so a content owner can compare volumes across agents and over time without knowing which model produced the number. Different normalised representations remain different ingested sequences and may therefore produce different counts.
 
 `tokens_ingested` counts the same content in the generation model's tokeniser (the model identified in `model_id` on the corresponding `turn_completed` event), not the retrieval or embedding model's tokeniser. It is supplementary. Token counts are model-specific, change when a vendor revises a tokeniser, and are not comparable between agents, so a consumer cannot aggregate them across emitters or treat a difference as a difference in volume. Emitters SHOULD send `chars_ingested` where they send `tokens_ingested`, and consumers that receive only token counts SHOULD record which model produced them.
+
+#### Provenance and content fingerprints
+
+`provenance` describes the delivery path by which the grounded representation reached the agent:
+
+| Value | Description |
+|-------|-------------|
+| `agent_fetched` | The agent obtained the representation directly from the publisher or from publisher-authorised origin or edge infrastructure for this session |
+| `agent_cached` | The agent reused a representation it had obtained before this session |
+| `third_party_sourced` | The representation reached the agent through an intermediary rather than through a direct publisher-authorised retrieval by the agent in this session |
+
+The field describes delivery path, not evidence quality. An emitter declaring Grounding or Citation conformance SHOULD include it when the path is known. It remains optional because an agent may not be able to distinguish its own earlier fetch from intermediary delivery. Consumers MUST NOT infer a value when it is absent.
+
+Emitters MUST keep `provenance` and `cached` consistent: `agent_fetched` requires `cached: false`, and `agent_cached` requires `cached: true`. `third_party_sourced` leaves `cached` unconstrained because an intermediary-sourced representation may be used immediately or cached by the agent before grounding.
+
+`content_fingerprint` contains:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scheme` | string | Yes | Open identifier for the fingerprint or provenance scheme checked |
+| `detected` | boolean | Yes | Emitter claim that the scheme's signal was found in the exact grounded representation |
+| `value` | string | No | Scheme-defined fingerprint or identifier value, when the scheme produces one |
+
+`detected` reports a grounding-time observation by the emitter. It does not establish that the signal is authentic, identify who applied it, prove that the content was used later in the output, or raise the evidentiary status of the grounding event. Those questions require profile-defined evidence and consumer trust policy outside the core schema.
+
+Output-side reuse is reported with `content_reproduced`, not a fingerprint-preservation field on `content_grounded`. A consumer MAY compare a grounding fingerprint with evidence about a reproduced output, but the two remain separate assertions about separate lifecycle stages.
+
+`scheme` is an open identifier. Emitters SHOULD use a globally collision-resistant value. Core does not register schemes, interpret `value`, or assign capabilities or evidence status from a scheme identifier. A profile MAY define scheme-specific processing rules.
 
 #### Grounding scope
 
@@ -1247,6 +1279,15 @@ the material and cannot record an uncredited copy. When migrating historical
 v0.1 data, consumers MAY treat a `direct_quote` citation as an implied
 reproduction of its excerpt. V1 emitters record reproduction explicitly and
 SHOULD NOT rely on that inference.
+
+V1 grounding fingerprints report detection only. A preview implementation that
+used `data.content_fingerprint.preserved_in_output` removes that field during
+migration. When its value was `true` and the historical record contains enough
+information to populate every required `content_reproduced` field, the
+implementation MAY also create the corresponding reproduction event. It MUST
+NOT synthesize a reproduction event from `false` or incomplete historical data.
+A grounding event MAY retain `content_fingerprint.scheme`, `detected`, and a
+scheme-defined `value`.
 
 Preview versions (0.x) use two-component version numbers. From 1.0.0 onward, versions follow [semantic versioning](https://semver.org/):
 

--- a/telemetry-session.json
+++ b/telemetry-session.json
@@ -149,12 +149,14 @@
                 "properties": {
                   "scope": { "$ref": "#/$defs/GroundingScope" },
                   "cached": { "type": "boolean" },
+                  "provenance": { "$ref": "#/$defs/SourceProvenance" },
                   "chars_ingested": { "type": "integer", "minimum": 0, "description": "Unicode code points in the exact text placed in the generation context, without normalising solely for counting. Portable across emitters; preferred over tokens_ingested (section 6.4)." },
                   "tokens_ingested": { "type": "integer", "minimum": 0, "description": "Token count of the same content in the emitter's own tokeniser. Supplementary: not comparable between emitters (section 6.4)." },
                   "content_version": { "type": "string" },
                   "content_last_modified": { "type": "string", "format": "date-time" },
                   "content_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
-                  "media_type": { "$ref": "#/$defs/MediaType" }
+                  "media_type": { "$ref": "#/$defs/MediaType" },
+                  "content_fingerprint": { "$ref": "#/$defs/ContentFingerprint" }
                 }
               }
             }
@@ -399,6 +401,33 @@
       "type": "string",
       "description": "Whether content informed all subsequent responses in the session or a specific turn only",
       "enum": ["session", "turn"]
+    },
+    "SourceProvenance": {
+      "type": "string",
+      "description": "How the grounded representation reached the agent. Describes delivery path, not evidence quality.",
+      "enum": ["agent_fetched", "agent_cached", "third_party_sourced"]
+    },
+    "ContentFingerprint": {
+      "type": "object",
+      "description": "Emitter-reported detection of a fingerprint or provenance signal in the exact grounded representation. Core does not interpret schemes or assign evidence status from detection.",
+      "required": ["scheme", "detected"],
+      "properties": {
+        "scheme": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Open identifier for the fingerprint or provenance scheme checked. Globally collision-resistant values are recommended."
+        },
+        "detected": {
+          "type": "boolean",
+          "description": "Emitter claim that the scheme's signal was found in the grounded representation"
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional scheme-defined fingerprint or identifier value"
+        }
+      },
+      "additionalProperties": true
     },
     "PresentationKind": {
       "type": "string",

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,8 @@ Run from the repository root. Without uv: `pip install jsonschema`, then `python
 - Reproduction cases: credited quotation (reproduction + direct_quote citation sharing an output element) and uncredited reproduction in unpresented API output
 - Text, image, audio, video, suppressed-citation, and repeated-presentation cases
 - Exact presentation-to-engagement correlation across session and standalone envelopes
-- Multi-turn sessions, cached grounding
+- Multi-turn sessions and cached grounding
+- Grounding provenance paths and generic fingerprint detection across session, standalone-event, and event-batch envelopes
 - Custom response_mode values
 
 Each test file has a `_test_description` field explaining what it demonstrates.
@@ -50,5 +51,6 @@ Some rules cannot be expressed in JSON Schema alone. These are tested as applica
 - `session_id` or `ctx_token` on a standalone event or event batch envelope at Grounding conformance and above (sections 5.7.5, 7.1)
 - Manifest rejection rules: duplicate `keys[].id`, and `domains` entries that are not the manifest's own host or a subdomain of it (sections 8.6, 8.7)
 - Withdrawn `ip_hash` prohibition on `content_retrieved` data (section 9.1 migration rule)
+- Grounding provenance/cache consistency and the prohibition on `preserved_in_output` in `content_fingerprint` (sections 5.7.5, 6.4, 12.1)
 
 Valid fixtures must pass both JSON Schema and these checks; `invalid/` fixtures that pass JSON Schema but fail a check are documented in `validate.py`. The `agent_id`-at-Grounding requirement is not fixture-tested: it depends on the emitter's declared conformance level, which the fixtures do not carry.

--- a/tests/invalid/grounding-fingerprint-missing-detected.json
+++ b/tests/invalid/grounding-fingerprint-missing-detected.json
@@ -1,0 +1,21 @@
+{
+  "_test_description": "Grounding event carries content_fingerprint without required detected. Must fail JSON Schema.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440182",
+  "started_at": "2026-08-12T10:20:00Z",
+  "events": [
+    {
+      "type": "content_grounded",
+      "timestamp": "2026-08-12T10:20:01Z",
+      "content_id": "publisher:article:99",
+      "data": {
+        "scope": "turn",
+        "cached": false,
+        "provenance": "agent_fetched",
+        "content_fingerprint": {
+          "scheme": "https://example.org/fingerprint/v1"
+        }
+      }
+    }
+  ]
+}

--- a/tests/invalid/grounding-fingerprint-preserved-in-output.json
+++ b/tests/invalid/grounding-fingerprint-preserved-in-output.json
@@ -1,0 +1,23 @@
+{
+  "_test_description": "Grounding fingerprint uses withdrawn preserved_in_output instead of a content_reproduced event. Passes the extensible schema but violates the v1 migration rule.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440183",
+  "started_at": "2026-08-12T10:30:00Z",
+  "events": [
+    {
+      "type": "content_grounded",
+      "timestamp": "2026-08-12T10:30:01Z",
+      "content_id": "publisher:article:100",
+      "data": {
+        "scope": "turn",
+        "cached": false,
+        "provenance": "agent_fetched",
+        "content_fingerprint": {
+          "scheme": "https://example.org/fingerprint/v1",
+          "detected": true,
+          "preserved_in_output": true
+        }
+      }
+    }
+  ]
+}

--- a/tests/invalid/grounding-provenance-cached-conflict.json
+++ b/tests/invalid/grounding-provenance-cached-conflict.json
@@ -1,0 +1,18 @@
+{
+  "_test_description": "Grounding event declares agent_fetched with cached true. Passes JSON Schema but violates section 6.4 provenance consistency.",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440184",
+  "started_at": "2026-08-12T10:40:00Z",
+  "events": [
+    {
+      "type": "content_grounded",
+      "timestamp": "2026-08-12T10:40:01Z",
+      "content_id": "publisher:article:101",
+      "data": {
+        "scope": "turn",
+        "cached": true,
+        "provenance": "agent_fetched"
+      }
+    }
+  ]
+}

--- a/tests/valid/event-batch-grounding-provenance.json
+++ b/tests/valid/event-batch-grounding-provenance.json
@@ -1,0 +1,36 @@
+{
+  "_test_description": "Batch envelope carrying grounding events from cached and third-party-sourced representations, exercising the shared provenance schema across batch delivery.",
+  "document_type": "event_batch",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440181",
+  "agent_id": "enterprise-rag-v1",
+  "started_at": "2026-08-12T10:10:00Z",
+  "events": [
+    {
+      "type": "content_grounded",
+      "timestamp": "2026-08-12T10:10:01Z",
+      "content_id": "publisher:cached:7",
+      "data": {
+        "scope": "session",
+        "cached": true,
+        "provenance": "agent_cached",
+        "chars_ingested": 900
+      }
+    },
+    {
+      "type": "content_grounded",
+      "timestamp": "2026-08-12T10:10:02Z",
+      "content_id": "repository:item:9",
+      "data": {
+        "scope": "turn",
+        "cached": false,
+        "provenance": "third_party_sourced",
+        "chars_ingested": 500,
+        "content_fingerprint": {
+          "scheme": "https://example.org/fingerprint/v1",
+          "detected": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/valid/event-standalone-grounding-fingerprint.json
+++ b/tests/valid/event-standalone-grounding-fingerprint.json
@@ -1,0 +1,26 @@
+{
+  "_test_description": "Standalone grounding event from a publisher-authorised live fetch with an emitter-reported generic fingerprint detection. The event schema is shared by session, standalone and batch envelopes.",
+  "document_type": "event",
+  "schema_version": "0.1",
+  "session_id": "660e8400-e29b-41d4-a716-446655440180",
+  "agent_id": "research-agent-v1",
+  "started_at": "2026-08-12T10:00:00Z",
+  "event": {
+    "type": "content_grounded",
+    "timestamp": "2026-08-12T10:00:01Z",
+    "content_url": "https://publisher.example/articles/42",
+    "content_id": "publisher:article:42",
+    "data": {
+      "scope": "turn",
+      "cached": false,
+      "provenance": "agent_fetched",
+      "chars_ingested": 2400,
+      "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "content_fingerprint": {
+        "scheme": "https://example.org/fingerprint/v1",
+        "detected": true,
+        "value": "fp_42"
+      }
+    }
+  }
+}

--- a/tests/valid/session-cached-grounding.json
+++ b/tests/valid/session-cached-grounding.json
@@ -1,5 +1,5 @@
 {
-  "_test_description": "Grounding from agent-side cache with no retrieval event. license_ref preserved from the original retrieval, as recommended by section 6.4.",
+  "_test_description": "Session document with agent-cached grounding and emitter-reported generic fingerprint detection. license_ref is preserved from the original retrieval, as recommended by section 6.4.",
   "schema_version": "0.1",
   "session_id": "660e8400-e29b-41d4-a716-446655440004",
   "agent_id": "copilot-v3",
@@ -15,10 +15,16 @@
       "data": {
         "scope": "session",
         "cached": true,
+        "provenance": "agent_cached",
         "chars_ingested": 11200,
         "tokens_ingested": 2800,
         "content_last_modified": "2026-03-27T16:00:00Z",
         "content_hash": "sha256:c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "content_fingerprint": {
+          "scheme": "org.example.fingerprint.v1",
+          "detected": true,
+          "value": "fp_cached_42"
+        },
         "media_type": "text"
       }
     },

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -55,6 +55,11 @@ except ImportError:
 #    manifest's own host or a subdomain of it (section 8.6). JSON Schema
 #    cannot compare values across array items or against the manifest's id.
 #
+# 5. Grounding provenance and fingerprint migration (sections 5.7.5, 6.4, 12.1):
+#    agent_fetched requires cached false; agent_cached requires cached true.
+#    content_fingerprint MUST NOT carry preserved_in_output because output-side
+#    reuse is represented by content_reproduced.
+#
 # Not checked here: agent_id at Grounding/Citation conformance (section
 # 5.7) depends on the emitter's declared conformance level, which fixtures do
 # not carry, so it is out of scope for the fixture suite.
@@ -100,6 +105,14 @@ APPLICATION_LAYER_VIOLATIONS = {
         "Retrieval event carries ip_hash in data. "
         "Violates section 9.1: the field was withdrawn in v1 and emitters "
         "MUST NOT populate it."
+    ),
+    "grounding-fingerprint-preserved-in-output.json": (
+        "Grounding fingerprint carries preserved_in_output. "
+        "Violates section 6.4: output-side reuse is reported as content_reproduced."
+    ),
+    "grounding-provenance-cached-conflict.json": (
+        "Grounding event declares agent_fetched with cached true. "
+        "Violates section 6.4: agent_fetched requires cached false."
     ),
 }
 
@@ -343,6 +356,29 @@ def check_v1_migration_prohibitions(data):
     return violations
 
 
+def check_grounding_provenance(data):
+    """Check the provenance/cached pairings required by section 6.4."""
+    violations = []
+    for event in _iter_events(data):
+        if event.get("type") != "content_grounded":
+            continue
+        event_data = event.get("data")
+        if not isinstance(event_data, dict):
+            continue
+        provenance = event_data.get("provenance")
+        cached = event_data.get("cached")
+        if provenance == "agent_fetched" and cached is not False:
+            violations.append("content_grounded with agent_fetched does not carry cached false")
+        if provenance == "agent_cached" and cached is not True:
+            violations.append("content_grounded with agent_cached does not carry cached true")
+        fingerprint = event_data.get("content_fingerprint")
+        if isinstance(fingerprint, dict) and "preserved_in_output" in fingerprint:
+            violations.append(
+                "content_fingerprint carries preserved_in_output; use content_reproduced"
+            )
+    return violations
+
+
 def check_application_layer(data):
     """Run every application-layer conformance rule and return all violations."""
     return (
@@ -350,6 +386,7 @@ def check_application_layer(data):
         + check_content_identifier(data)
         + check_session_or_ctx_token(data)
         + check_v1_migration_prohibitions(data)
+        + check_grounding_provenance(data)
     )
 
 


### PR DESCRIPTION
This implements the Board-approved direction for #10 on top of the current `v1-draft` in one commit.

It keeps grounding provenance and fingerprint detection in core, removes the old output-side `preserved_in_output` semantics in favour of `content_reproduced`, and adds the requested session, standalone-event, and event-batch coverage.

The specification now states the claim boundaries directly: provenance describes delivery path, fingerprint detection is an emitter observation, and neither establishes authenticity, ownership, entitlement, grounding truth, or later output reuse. Evidence mechanics remain outside this change.

Validation:

- `python3 tests/validate.py` - 73/73 passed
- `python3 tests/check_examples.py` - 9/9 complete examples passed

This is offered as the clean current-`v1-draft` implementation of #10 so the original proposal and discussion remain the source of the change.